### PR TITLE
CTCP-129: Updated util specs to test against expected rendered text

### DIFF
--- a/test/utils/AddEventsHelperSpec.scala
+++ b/test/utils/AddEventsHelperSpec.scala
@@ -104,7 +104,7 @@ class AddEventsHelperSpec extends SpecBase {
           helper.cyaListOfEvent(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("addEvent.event.label", eventIndex.display).toText,
+                content = s"Event ${eventIndex.display}".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(place.toText),
@@ -112,9 +112,9 @@ class AddEventsHelperSpec extends SpecBase {
                 Actions(items =
                   Seq(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = CheckEventAnswersController.onPageLoad(mrn, eventIndex).url,
-                      visuallyHiddenText = Some(messages("addEvent.change.hidden", eventIndex.display, place))
+                      visuallyHiddenText = Some(s"event ${eventIndex.display} at $place")
                     )
                   )
                 )
@@ -136,7 +136,7 @@ class AddEventsHelperSpec extends SpecBase {
           helper.cyaListOfEvent(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("addEvent.event.label", eventIndex.display).toText,
+                content = s"Event ${eventIndex.display}".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(countryCode.code.toText),
@@ -144,9 +144,9 @@ class AddEventsHelperSpec extends SpecBase {
                 Actions(items =
                   Seq(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = CheckEventAnswersController.onPageLoad(mrn, eventIndex).url,
-                      visuallyHiddenText = Some(messages("addEvent.change.hidden", eventIndex.display, countryCode.code))
+                      visuallyHiddenText = Some(s"event ${eventIndex.display} at ${countryCode.code}")
                     )
                   )
                 )

--- a/test/utils/CheckEventAnswersHelperSpec.scala
+++ b/test/utils/CheckEventAnswersHelperSpec.scala
@@ -57,17 +57,17 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.isTranshipment(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("isTranshipment.checkYourAnswersLabel").toText,
+                content = "Were the goods moved to a different vehicle or container?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages("site.yes").toText),
+              value = Value("Yes".toText),
               actions = Some(
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = IsTranshipmentController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("isTranshipment.change.hidden")),
+                      visuallyHiddenText = Some("if the goods were moved to a different vehicle or container"),
                       attributes = Map("id" -> s"change-is-transhipment-${eventIndex.display}")
                     )
                   )
@@ -103,17 +103,17 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.transhipmentType(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("transhipmentType.checkYourAnswersLabel").toText,
+                content = "Where were the goods moved?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages(s"transhipmentType.checkYourAnswers.$transhipmentType").toText),
+              value = Value("A different container".toText),
               actions = Some(
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = TranshipmentTypeController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("transhipmentType.change.hidden")),
+                      visuallyHiddenText = Some("where the goods moved to"),
                       attributes = Map("id" -> s"transhipment-type-${eventIndex.display}")
                     )
                   )
@@ -149,7 +149,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.containerNumber(eventIndex, containerIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("addContainer.containerList.label", containerIndex.display).toText,
+                content = s"Container ${containerIndex.display}".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(containerDomain.containerNumber.toText),
@@ -157,9 +157,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = ContainerNumberController.onPageLoad(mrn, eventIndex, containerIndex, mode).url,
-                      visuallyHiddenText = Some(messages("containerNumber.change.hidden", containerDomain.containerNumber)),
+                      visuallyHiddenText = Some(s"container ${containerDomain.containerNumber}"),
                       attributes = Map("id" -> s"change-container-${containerIndex.display}")
                     )
                   )
@@ -197,7 +197,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
             helper.eventCountry(eventIndex)(CountryList(Nil)) mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("eventCountry.checkYourAnswersLabel").toText,
+                  content = "Which country were the goods in when the event happened?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(countryCode.code.toText),
@@ -205,9 +205,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = List(
                       ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = EventCountryController.onPageLoad(mrn, eventIndex, mode).url,
-                        visuallyHiddenText = Some(messages("eventCountry.change.hidden")),
+                        visuallyHiddenText = Some("which country the goods were in when the event happened"),
                         attributes = Map("id" -> s"change-event-country-${eventIndex.display}")
                       )
                     )
@@ -230,7 +230,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
             helper.eventCountry(eventIndex)(CountryList(Seq(country))) mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("eventCountry.checkYourAnswersLabel").toText,
+                  content = "Which country were the goods in when the event happened?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(country.description.toText),
@@ -238,9 +238,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = List(
                       ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = EventCountryController.onPageLoad(mrn, eventIndex, mode).url,
-                        visuallyHiddenText = Some(messages("eventCountry.change.hidden")),
+                        visuallyHiddenText = Some("which country the goods were in when the event happened"),
                         attributes = Map("id" -> s"change-event-country-${eventIndex.display}")
                       )
                     )
@@ -277,7 +277,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.eventPlace(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("eventPlace.checkYourAnswersLabel").toText,
+                content = "Where did the event happen?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(place.toText),
@@ -285,9 +285,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = EventPlaceController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("eventPlace.change.hidden")),
+                      visuallyHiddenText = Some("where the event happened"),
                       attributes = Map("id" -> s"change-event-place-${eventIndex.display}")
                     )
                   )
@@ -321,17 +321,17 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.eventReported(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("eventReported.checkYourAnswersLabel").toText,
+                content = "Has this event been reported to customs?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages("site.no").toText),
+              value = Value("No".toText),
               actions = Some(
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = EventReportedController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("eventReported.change.hidden")),
+                      visuallyHiddenText = Some("if this event has been reported to customs"),
                       attributes = Map("id" -> s"change-event-reported-${eventIndex.display}")
                     )
                   )
@@ -367,7 +367,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.incidentInformation(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("incidentInformation.checkYourAnswersLabel").toText,
+                content = "What happened on the journey?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(incident.toText),
@@ -375,9 +375,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = IncidentInformationController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("incidentInformation.change.hidden")),
+                      visuallyHiddenText = Some("what happened on the journey"),
                       attributes = Map("id" -> s"change-incident-information-${eventIndex.display}")
                     )
                   )
@@ -413,7 +413,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.transportIdentity(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("transportIdentity.checkYourAnswersLabel").toText,
+                content = "What is the name, registration or reference of the new vehicle?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(vehicle.toText),
@@ -421,9 +421,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = TransportIdentityController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("transportIdentity.change.hidden")),
+                      visuallyHiddenText = Some("the name, registration or reference of the new vehicle"),
                       attributes = Map("id" -> s"transport-identity-${eventIndex.display}")
                     )
                   )
@@ -461,7 +461,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
             helper.transportNationality(eventIndex)(CountryList(Nil)) mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("transportNationality.checkYourAnswersLabel").toText,
+                  content = "Which country is the vehicle registered in?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(countryCode.code.toText),
@@ -469,9 +469,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = List(
                       ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = TransportNationalityController.onPageLoad(mrn, eventIndex, mode).url,
-                        visuallyHiddenText = Some(messages("transportNationality.change.hidden")),
+                        visuallyHiddenText = Some("the country where the vehicle is registered"),
                         attributes = Map("id" -> s"transport-nationality-${eventIndex.display}")
                       )
                     )
@@ -494,7 +494,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
             helper.transportNationality(eventIndex)(CountryList(Seq(country))) mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("transportNationality.checkYourAnswersLabel").toText,
+                  content = "Which country is the vehicle registered in?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(country.description.toText),
@@ -502,9 +502,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = List(
                       ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = TransportNationalityController.onPageLoad(mrn, eventIndex, mode).url,
-                        visuallyHiddenText = Some(messages("transportNationality.change.hidden")),
+                        visuallyHiddenText = Some("the country where the vehicle is registered"),
                         attributes = Map("id" -> s"transport-nationality-${eventIndex.display}")
                       )
                     )
@@ -539,17 +539,17 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.haveSealsChanged(eventIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("haveSealsChanged.checkYourAnswersLabel").toText,
+                content = "Have any of the official customs seals changed?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages("site.yes").toText),
+              value = Value("Yes".toText),
               actions = Some(
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = HaveSealsChangedController.onPageLoad(mrn, eventIndex, mode).url,
-                      visuallyHiddenText = Some(messages("haveSealsChanged.change.hidden")),
+                      visuallyHiddenText = Some("if any of the official customs seals have changed"),
                       attributes = Map("id" -> s"seals-changed-${eventIndex.display}")
                     )
                   )
@@ -585,7 +585,7 @@ class CheckEventAnswersHelperSpec extends SpecBase {
           helper.sealIdentity(eventIndex, sealIndex) mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("addSeal.sealList.label", sealIndex.display).toText,
+                content = s"Official customs seal ${sealIndex.display}".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(seal.numberOrMark.toText),
@@ -593,9 +593,9 @@ class CheckEventAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = List(
                     ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = SealIdentityController.onPageLoad(mrn, eventIndex, sealIndex, mode).url,
-                      visuallyHiddenText = Some(messages("sealIdentity.change.hidden", seal.numberOrMark)),
+                      visuallyHiddenText = Some(s"official customs seal ${seal.numberOrMark}"),
                       attributes = Map("id" -> s"change-seal-${sealIndex.display}")
                     )
                   )

--- a/test/utils/CheckYourAnswersHelperSpec.scala
+++ b/test/utils/CheckYourAnswersHelperSpec.scala
@@ -75,7 +75,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.eoriNumber mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("eoriNumber.checkYourAnswersLabel", name).toText,
+                content = s"What is the EORI number for $name?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(eori.toText),
@@ -83,9 +83,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.ConsigneeEoriNumberController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("eoriNumber.change.hidden", name)),
+                      visuallyHiddenText = Some(s"the EORI number for $name"),
                       attributes = Map("id" -> "change-eori-number")
                     )
                   )
@@ -119,7 +119,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.consigneeName mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("consigneeName.checkYourAnswersLabel").toText,
+                content = "What is the name of the authorised consignee?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(name.toText),
@@ -127,9 +127,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.ConsigneeNameController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("consigneeName.change.hidden")),
+                      visuallyHiddenText = Some("the name of the authorised consignee"),
                       attributes = Map("id" -> "change-consignee-name")
                     )
                   )
@@ -163,7 +163,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.placeOfNotification mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("placeOfNotification.checkYourAnswersLabel").toText,
+                content = "Where are you completing this arrival notification?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(location.toText),
@@ -171,9 +171,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.PlaceOfNotificationController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("placeOfNotification.change.hidden")),
+                      visuallyHiddenText = Some("where you are completing this arrival notification"),
                       attributes = Map("id" -> "change-place-of-notification")
                     )
                   )
@@ -207,17 +207,17 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.isTraderAddressPlaceOfNotification mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("isTraderAddressPlaceOfNotification.checkYourAnswersLabel").toText,
+                content = "Are you completing this arrival notification at the trader’s address?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages("site.yes").toText),
+              value = Value("Yes".toText),
               actions = Some(
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.IsTraderAddressPlaceOfNotificationController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("isTraderAddressPlaceOfNotification.change.hidden")),
+                      visuallyHiddenText = Some("if you are completing this arrival notification at the trader’s address"),
                       attributes = Map("id" -> "change-trader-address-place-of-notification")
                     )
                   )
@@ -251,17 +251,17 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.incidentOnRoute mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("incidentOnRoute.checkYourAnswersLabel").toText,
+                content = "Did any events happen on the journey?".toText,
                 classes = "govuk-!-width-one-half"
               ),
-              value = Value(messages("site.yes").toText),
+              value = Value("Yes".toText),
               actions = Some(
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.IncidentOnRouteController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("incidentOnRoute.change.hidden")),
+                      visuallyHiddenText = Some("if there was an event on the journey"),
                       attributes = Map("id" -> "change-incident-on-route")
                     )
                   )
@@ -295,7 +295,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.traderName mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("traderName.checkYourAnswersLabel").toText,
+                content = "Name".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(name.toText),
@@ -303,9 +303,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.TraderNameController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("traderName.change.hidden")),
+                      visuallyHiddenText = Some("name of trader"),
                       attributes = Map("id" -> "change-trader-name")
                     )
                   )
@@ -339,7 +339,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.traderEori mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("traderEori.checkYourAnswersLabel").toText,
+                content = "EORI number".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(eori.toText),
@@ -347,9 +347,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.TraderEoriController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("traderEori.change.hidden")),
+                      visuallyHiddenText = Some("EORI number of trader"),
                       attributes = Map("id" -> "change-trader-eori")
                     )
                   )
@@ -383,7 +383,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.traderAddress mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("traderAddress.checkYourAnswersLabel").toText,
+                content = "Address".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(HtmlContent(s"${address.buildingAndStreet}<br>${address.city}<br>${address.postcode}")),
@@ -391,9 +391,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.TraderAddressController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("traderAddress.change.hidden")),
+                      visuallyHiddenText = Some("address of trader"),
                       attributes = Map("id" -> "change-trader-address")
                     )
                   )
@@ -442,7 +442,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.consigneeAddress mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("consigneeAddress.checkYourAnswersLabel", name).toText,
+                content = s"Address".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(HtmlContent(s"${address.buildingAndStreet}<br>${address.city}<br>${address.postcode}")),
@@ -450,9 +450,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.ConsigneeAddressController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("consigneeAddress.change.hidden", name)),
+                      visuallyHiddenText = Some(s"$name’s address"),
                       attributes = Map("id" -> "change-consignee-address")
                     )
                   )
@@ -486,7 +486,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.authorisedLocation mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("authorisedLocation.checkYourAnswersLabel").toText,
+                content = "Authorised location".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(location.toText),
@@ -494,9 +494,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.AuthorisedLocationController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("authorisedLocation.change.hidden")),
+                      visuallyHiddenText = Some("the authorised location"),
                       attributes = Map("id" -> "change-authorised-location")
                     )
                   )
@@ -530,7 +530,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
           checkYourAnswersHelper.customsSubPlace mustBe Some(
             SummaryListRow(
               key = Key(
-                content = messages("customsSubPlace.checkYourAnswersLabel").toText,
+                content = "Which Customs-approved location has the goods?".toText,
                 classes = "govuk-!-width-one-half"
               ),
               value = Value(location.toText),
@@ -538,9 +538,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                 new Actions(
                   items = Seq(
                     new ActionItem(
-                      content = messages("site.edit").toText,
+                      content = "Change".toText,
                       href = routes.CustomsSubPlaceController.onPageLoad(mrn, mode).url,
-                      visuallyHiddenText = Some(messages("customsSubPlace.change.hidden")),
+                      visuallyHiddenText = Some("the customs sub-place or approved location"),
                       attributes = Map("id" -> "change-customs-sub-place")
                     )
                   )
@@ -592,7 +592,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.simplifiedCustomsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.simplified.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location’s address?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(customsOfficeId.toText),
@@ -600,9 +600,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeSimplifiedController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.simplified.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -626,7 +626,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.simplifiedCustomsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.simplified.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location’s address?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(customsOfficeId.toText),
@@ -634,9 +634,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeSimplifiedController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.simplified.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -663,7 +663,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.simplifiedCustomsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.simplified.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location’s address?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(s"$customsOfficeName ($customsOfficeId)".toText),
@@ -671,9 +671,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeSimplifiedController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.simplified.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -697,7 +697,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.simplifiedCustomsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.simplified.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location’s address?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(s"$customsOfficeName ($customsOfficeId)".toText),
@@ -705,9 +705,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeSimplifiedController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.simplified.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -760,7 +760,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.customsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(customsOfficeId.toText),
@@ -768,9 +768,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -794,7 +794,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.customsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(customsOfficeId.toText),
@@ -802,9 +802,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -831,7 +831,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.customsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(s"$customsOfficeName ($customsOfficeId)".toText),
@@ -839,9 +839,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )
@@ -865,7 +865,7 @@ class CheckYourAnswersHelperSpec extends SpecBase {
             checkYourAnswersHelper.customsOffice mustBe Some(
               SummaryListRow(
                 key = Key(
-                  content = messages("customsOffice.checkYourAnswersLabel", location).toText,
+                  content = s"Which Customs office supervises $location?".toText,
                   classes = "govuk-!-width-one-half"
                 ),
                 value = Value(s"$customsOfficeName ($customsOfficeId)".toText),
@@ -873,9 +873,9 @@ class CheckYourAnswersHelperSpec extends SpecBase {
                   new Actions(
                     items = Seq(
                       new ActionItem(
-                        content = messages("site.edit").toText,
+                        content = "Change".toText,
                         href = routes.CustomsOfficeController.onPageLoad(mrn, mode).url,
-                        visuallyHiddenText = Some(messages("customsOffice.change.hidden", location)),
+                        visuallyHiddenText = Some(s"which Customs office supervises $location"),
                         attributes = Map("id" -> "change-presentation-office")
                       )
                     )

--- a/test/views/CheckYourAnswersViewSpec.scala
+++ b/test/views/CheckYourAnswersViewSpec.scala
@@ -17,34 +17,41 @@
 package views
 
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
 import viewModels.sections.Section
-import views.behaviours.ViewBehaviours
+import views.behaviours.SummaryListViewBehaviours
 import views.html.CheckYourAnswersView
 
-class CheckYourAnswersViewSpec extends ViewBehaviours {
+class CheckYourAnswersViewSpec extends SummaryListViewBehaviours {
 
   override val prefix: String = "checkYourAnswers"
 
-  val answersList: Seq[Section] = Seq(
+  val sections: Seq[Section] = Seq(
     Section(
-      messages("checkYourAnswers.section.traderDetails"),
+      "Section title",
       Nil
     )
   )
 
+  override def summaryLists: Seq[SummaryList] = sections.map(
+    section => new SummaryList(section.rows)
+  )
+
   override def view: HtmlFormat.Appendable =
-    injector.instanceOf[CheckYourAnswersView].apply(mrn, answersList)(fakeRequest, messages)
+    injector.instanceOf[CheckYourAnswersView].apply(mrn, sections)(fakeRequest, messages)
 
   behave like pageWithBackLink
 
   behave like pageWithHeading()
 
-  behave like pageWithContent("h2", messages("checkYourAnswers.confirmation.heading"))
+  behave like pageWithSummaryLists()
 
-  behave like pageWithContent("h2", messages("checkYourAnswers.section.traderDetails"))
+  behave like pageWithContent("h2", "Section title")
 
-  behave like pageWithContent("p", messages("checkYourAnswers.confirmation.paragraph"))
+  behave like pageWithContent("h2", "Now send your arrival notification")
 
-  behave like pageWithSubmitButton(messages("site.confirmAndSend"))
+  behave like pageWithContent("p", "By sending this you are confirming that the details you are providing are correct, to the best of your knowledge.")
+
+  behave like pageWithSubmitButton("Confirm and send")
 
 }


### PR DESCRIPTION
### Main focus:

Updated the tests for the util classes so that they test against the actual text we expect to be rendered on the page. This will give us confidence all the section titles and hidden text etc we render on the check your answers pages is correct.

### Also:

Added SummaryListViewBehaviours to the CheckYourAnswersViewSpec