### PR TITLE
CTCP-129 Add back support for overriding startUrl

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -46,17 +46,22 @@ class FrontendAppConfig @Inject() (configuration: Configuration, service: Servic
   lazy val serviceUrl: String                            = s"$manageTransitMovementsUrl/what-do-you-want-to-do"
   lazy val manageTransitMovementsViewArrivalsUrl: String = s"$manageTransitMovementsUrl/view-arrivals"
 
-  lazy val authUrl: String            = service.baseUrl("auth")
-  lazy val loginUrl: String           = configuration.get[String]("urls.login")
-  lazy val loginContinueUrl: String   = configuration.get[String]("urls.loginContinue")
-  lazy val baseDestinationUrl: String = service.baseUrl("destination")
-  lazy val destinationUrl: String     = baseDestinationUrl + "/transit-movements-trader-at-destination"
-  lazy val referenceDataUrl: String   = service.baseUrl("referenceData") + "/transit-movements-trader-reference-data"
-  lazy val timeoutSeconds: Int        = configuration.get[Int]("session.timeoutSeconds")
-  lazy val countdownSeconds: Int      = configuration.get[Int]("session.countdownSeconds")
-  lazy val enrolmentProxyUrl: String  = service.baseUrl("enrolment-store-proxy") + "/enrolment-store-proxy"
-  lazy val nctsHelpdeskUrl: String    = configuration.get[String]("urls.nctsHelpdesk")
-  lazy val nctsEnquiriesUrl: String   = configuration.get[String]("urls.nctsEnquiries")
+  lazy val authUrl: String          = service.baseUrl("auth")
+  lazy val loginUrl: String         = configuration.get[String]("urls.login")
+  lazy val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
+
+  lazy val baseDestinationUrl: String          = service.baseUrl("destination")
+  private lazy val destinationStartUrl: String = service.getString("microservice.services.destination.startUrl")
+  lazy val destinationUrl: String              = s"$baseDestinationUrl/$destinationStartUrl"
+
+  // Does this have the same bug?
+  lazy val referenceDataUrl: String = service.baseUrl("referenceData") + "/transit-movements-trader-reference-data"
+
+  lazy val timeoutSeconds: Int       = configuration.get[Int]("session.timeoutSeconds")
+  lazy val countdownSeconds: Int     = configuration.get[Int]("session.countdownSeconds")
+  lazy val enrolmentProxyUrl: String = service.baseUrl("enrolment-store-proxy") + "/enrolment-store-proxy"
+  lazy val nctsHelpdeskUrl: String   = configuration.get[String]("urls.nctsHelpdesk")
+  lazy val nctsEnquiriesUrl: String  = configuration.get[String]("urls.nctsEnquiries")
 
   lazy val legacyEnrolmentKey: String           = configuration.get[String]("keys.legacy.enrolmentKey")
   lazy val legacyEnrolmentIdentifierKey: String = configuration.get[String]("keys.legacy.enrolmentIdentifierKey")

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -18,10 +18,9 @@ package config
 
 import com.google.inject.{Inject, Singleton}
 import play.api.Configuration
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
-class FrontendAppConfig @Inject() (configuration: Configuration, service: ServicesConfig) {
+class FrontendAppConfig @Inject() (configuration: Configuration) {
 
   val contactHost: String                  = configuration.get[String]("contact-frontend.host")
   val contactFormServiceIdentifier: String = "CTCTraders"
@@ -46,22 +45,21 @@ class FrontendAppConfig @Inject() (configuration: Configuration, service: Servic
   lazy val serviceUrl: String                            = s"$manageTransitMovementsUrl/what-do-you-want-to-do"
   lazy val manageTransitMovementsViewArrivalsUrl: String = s"$manageTransitMovementsUrl/view-arrivals"
 
-  lazy val authUrl: String          = service.baseUrl("auth")
   lazy val loginUrl: String         = configuration.get[String]("urls.login")
   lazy val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")
 
-  lazy val baseDestinationUrl: String          = service.baseUrl("destination")
-  private lazy val destinationStartUrl: String = service.getString("microservice.services.destination.startUrl")
-  lazy val destinationUrl: String              = s"$baseDestinationUrl/$destinationStartUrl"
+  lazy val baseDestinationUrl: String = configuration.get[Service]("microservice.services.destination").baseUrl
+  lazy val destinationUrl: String     = configuration.get[Service]("microservice.services.destination").fullServiceUrl
 
-  // Does this have the same bug?
-  lazy val referenceDataUrl: String = service.baseUrl("referenceData") + "/transit-movements-trader-reference-data"
+  lazy val referenceDataUrl: String = configuration.get[Service]("microservice.services.referenceData").fullServiceUrl
 
-  lazy val timeoutSeconds: Int       = configuration.get[Int]("session.timeoutSeconds")
-  lazy val countdownSeconds: Int     = configuration.get[Int]("session.countdownSeconds")
-  lazy val enrolmentProxyUrl: String = service.baseUrl("enrolment-store-proxy") + "/enrolment-store-proxy"
-  lazy val nctsHelpdeskUrl: String   = configuration.get[String]("urls.nctsHelpdesk")
-  lazy val nctsEnquiriesUrl: String  = configuration.get[String]("urls.nctsEnquiries")
+  lazy val timeoutSeconds: Int   = configuration.get[Int]("session.timeoutSeconds")
+  lazy val countdownSeconds: Int = configuration.get[Int]("session.countdownSeconds")
+
+  lazy val enrolmentProxyUrl: String = configuration.get[Service]("microservice.services.enrolment-store-proxy").fullServiceUrl
+
+  lazy val nctsHelpdeskUrl: String  = configuration.get[String]("urls.nctsHelpdesk")
+  lazy val nctsEnquiriesUrl: String = configuration.get[String]("urls.nctsEnquiries")
 
   lazy val legacyEnrolmentKey: String           = configuration.get[String]("keys.legacy.enrolmentKey")
   lazy val legacyEnrolmentIdentifierKey: String = configuration.get[String]("keys.legacy.enrolmentIdentifierKey")

--- a/app/config/Service.scala
+++ b/app/config/Service.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.{ConfigLoader, Configuration}
+
+import scala.language.implicitConversions
+
+final case class Service(host: String, port: String, protocol: String, startUrl: String) {
+
+  def baseUrl: String =
+    s"$protocol://$host:$port"
+
+  def fullServiceUrl: String =
+    s"$baseUrl/$startUrl"
+
+  override def toString: String =
+    baseUrl
+}
+
+object Service {
+
+  implicit lazy val configLoader: ConfigLoader[Service] = ConfigLoader {
+    config => prefix =>
+      val service  = Configuration(config).get[Configuration](prefix)
+      val host     = service.get[String]("host")
+      val port     = service.get[String]("port")
+      val protocol = service.get[String]("protocol")
+      val startUrl = service.get[String]("startUrl")
+
+      Service(host, port, protocol, startUrl)
+  }
+
+  implicit def convertToString(service: Service): String =
+    service.fullServiceUrl
+}

--- a/app/connectors/ArrivalMovementConnector.scala
+++ b/app/connectors/ArrivalMovementConnector.scala
@@ -57,6 +57,12 @@ class ArrivalMovementConnector @Inject() (val config: FrontendAppConfig, val htt
     }
   }
 
+  /** Author: Adam
+    * Comment: http://localhost:9481 does not support the following endpoint:
+    * http://localhost:9481/common-transit-convention-trader-at-destinatio/:rejectionLocation
+    *
+    * This must not be tested by a journey test when running with a stub.
+    */
   def getRejectionMessage(rejectionLocation: String)(implicit hc: HeaderCarrier): Future[Option[ArrivalNotificationRejectionMessage]] = {
     val serviceUrl = s"${config.baseDestinationUrl}$rejectionLocation"
     val header     = hc.withExtraHeaders(ChannelHeader(channel))
@@ -78,6 +84,12 @@ class ArrivalMovementConnector @Inject() (val config: FrontendAppConfig, val htt
     }
   }
 
+  /** Author: Adam
+    * Comment: http://localhost:9481 does not support the following endpoint:
+    * http://localhost:9481/common-transit-convention-trader-at-destinatio/:location
+    *
+    * This must not be tested by a journey test when running with a stub.
+    */
   def getArrivalNotificationMessage(location: String)(implicit hc: HeaderCarrier): Future[Option[ArrivalMovementRequest]] = {
     val serviceUrl = s"${config.baseDestinationUrl}$location"
     val header     = hc.withExtraHeaders(ChannelHeader(channel))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,12 +75,14 @@ microservice {
       protocol = http
       host = localhost
       port = 9482
+      startUrl = transit-movements-trader-reference-data
     }
 
     enrolment-store-proxy {
       protocol = http
       host = localhost
       port = 9481
+      startUrl = enrolment-store-proxy
     }
 
     tracking-consent-frontend {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -68,6 +68,7 @@ microservice {
       protocol = http
       host = localhost
       port = 9480
+      startUrl = transit-movements-trader-at-destination
     }
 
     referenceData {


### PR DESCRIPTION
- Destinations microservice in application.conf has startUrl overriden by service manager, this was no longer respected and resulted in the stub microservice returning a 404 not found for an endpoint it did not have