### PR TITLE
Fix goods item number field length validation

### DIFF
--- a/app/forms/Constants.scala
+++ b/app/forms/Constants.scala
@@ -26,5 +26,6 @@ object Constants {
   lazy val authorisationNumberLength: Int     = 35
   lazy val maxIncidentTextLength: Int         = 512
   lazy val itemNumberLength: Int              = 4
+  lazy val itemNumberMax: Int                 = 1999
   lazy val identificationNumberLength: Int    = 35
 }

--- a/app/forms/ItemNumberFormProvider.scala
+++ b/app/forms/ItemNumberFormProvider.scala
@@ -30,7 +30,7 @@ class ItemNumberFormProvider @Inject() extends Mappings {
       "value" -> text(s"$prefix.error.required")
         .verifying(
           forms.StopOnFirstFail[String](
-            exactLength(itemNumberLength, s"$prefix.error.length"),
+            maxLength(itemNumberLength, s"$prefix.error.length"),
             regexp(numericRegex, s"$prefix.error.invalidCharacters")
           )
         )

--- a/app/forms/ItemNumberFormProvider.scala
+++ b/app/forms/ItemNumberFormProvider.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import forms.Constants.itemNumberLength
+import forms.Constants.{itemNumberLength, itemNumberMax}
 import forms.mappings.Mappings
 import models.domain.StringFieldRegex.numericRegex
 import play.api.data.Form
@@ -31,7 +31,9 @@ class ItemNumberFormProvider @Inject() extends Mappings {
         .verifying(
           forms.StopOnFirstFail[String](
             maxLength(itemNumberLength, s"$prefix.error.length"),
-            regexp(numericRegex, s"$prefix.error.invalidCharacters")
+            regexp(numericRegex, s"$prefix.error.invalidCharacters"),
+            minimumIntValue(0, s"$prefix.error.range"),
+            maximumIntValue(itemNumberMax, s"$prefix.error.range")
           )
         )
     )

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -56,6 +56,26 @@ trait Constraints {
         }
     }
 
+  protected def maximumIntValue(maximum: Int, errorKey: String): Constraint[String] =
+    Constraint {
+      input =>
+        if (input.toInt <= maximum) {
+          Valid
+        } else {
+          Invalid(errorKey, maximum)
+        }
+    }
+
+  protected def minimumIntValue(min: Int, errorKey: String): Constraint[String] =
+    Constraint {
+      input =>
+        if (input.toInt > min) {
+          Valid
+        } else {
+          Invalid(errorKey, min)
+        }
+    }
+
   protected def inRange[A](itemIndex: A, minimum: A, maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
     Constraint {
       input =>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -566,11 +566,11 @@ incident.equipment.goodsItemNumber.change.hidden = goods item number {0}
 
 incident.equipment.itemNumber.title = What is the goods item number?
 incident.equipment.itemNumber.heading = What is the goods item number?
-incident.equipment.itemNumber.hint = This will be 4 characters long, for example 1234.
+incident.equipment.itemNumber.hint = This will be up to 4 characters long, for example 1999.
 incident.equipment.itemNumber.checkYourAnswersLabel = What is the goods item number?
 incident.equipment.itemNumber.error.required = Enter the goods item number
 incident.equipment.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
-incident.equipment.itemNumber.error.length = The goods item number must be 4 characters long
+incident.equipment.itemNumber.error.length = The goods item number must be 4 characters or less
 
 incident.equipment.itemNumber.addAnotherItemNumberYesNo.singular.title = You have added {0} goods item number
 incident.equipment.itemNumber.addAnotherItemNumberYesNo.singular.heading = You have added {0} goods item number

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -566,11 +566,12 @@ incident.equipment.goodsItemNumber.change.hidden = goods item number {0}
 
 incident.equipment.itemNumber.title = What is the goods item number?
 incident.equipment.itemNumber.heading = What is the goods item number?
-incident.equipment.itemNumber.hint = This will be up to 4 characters long, for example 1999.
+incident.equipment.itemNumber.hint = This can be up to 4 numbers long.
 incident.equipment.itemNumber.checkYourAnswersLabel = What is the goods item number?
 incident.equipment.itemNumber.error.required = Enter the goods item number
 incident.equipment.itemNumber.error.invalidCharacters = The goods item number must only include numbers 0 to 9
 incident.equipment.itemNumber.error.length = The goods item number must be 4 characters or less
+incident.equipment.itemNumber.error.range = The goods item number must be more than 0 and less than 2000
 
 incident.equipment.itemNumber.addAnotherItemNumberYesNo.singular.title = You have added {0} goods item number
 incident.equipment.itemNumber.addAnotherItemNumberYesNo.singular.heading = You have added {0} goods item number

--- a/test/forms/ItemNumberFormProviderSpec.scala
+++ b/test/forms/ItemNumberFormProviderSpec.scala
@@ -20,12 +20,18 @@ import forms.behaviours.StringFieldBehaviours
 import org.scalacheck.Gen
 import play.api.data.FormError
 
+import scala.collection.immutable.ArraySeq
+
 class ItemNumberFormProviderSpec extends StringFieldBehaviours {
 
   private val prefix = Gen.alphaNumStr.sample.value
   val requiredKey    = s"$prefix.error.required"
   val lengthKey      = s"$prefix.error.length"
+  val rangeKey       = s"$prefix.error.range"
   val maxLength      = 4
+  val maxLengthValue = 9999
+  val maxValue       = 1999
+  val minValue       = 1
 
   val form = new ItemNumberFormProvider()(prefix)
 
@@ -50,6 +56,21 @@ class ItemNumberFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like stringFieldWithMaximumIntValue(
+      form,
+      fieldName,
+      maxValue,
+      maxLengthValue,
+      FormError(fieldName, rangeKey, ArraySeq(maxValue))
+    )
+
+    behave like stringFieldWithMinimumIntValue(
+      form,
+      fieldName,
+      minValue,
+      FormError(fieldName, rangeKey, ArraySeq(minValue - 1))
     )
   }
 }

--- a/test/forms/ItemNumberFormProviderSpec.scala
+++ b/test/forms/ItemNumberFormProviderSpec.scala
@@ -25,7 +25,7 @@ class ItemNumberFormProviderSpec extends StringFieldBehaviours {
   private val prefix = Gen.alphaNumStr.sample.value
   val requiredKey    = s"$prefix.error.required"
   val lengthKey      = s"$prefix.error.length"
-  val exactLength    = 4
+  val maxLength      = 4
 
   val form = new ItemNumberFormProvider()(prefix)
 
@@ -36,14 +36,14 @@ class ItemNumberFormProviderSpec extends StringFieldBehaviours {
     behave like fieldThatBindsValidData(
       form,
       fieldName,
-      stringsWithLength(exactLength)
+      stringsWithLength(maxLength)
     )
 
-    behave like fieldWithExactLength(
+    behave like fieldWithMaxLength(
       form,
       fieldName,
-      exactLength = exactLength,
-      lengthError = FormError(fieldName, lengthKey, Seq(exactLength))
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
     )
 
     behave like mandatoryField(

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -116,4 +116,20 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
 
+  def stringFieldWithMaximumIntValue(form: Form[_], fieldName: String, max: Int, fieldMax: Int, expectedError: FormError): Unit =
+    s"must not bind values > $max and < $max" in {
+      forAll(positiveIntsMinMax(max, fieldMax)) {
+        number =>
+          val result = form.bind(Map(fieldName -> number.toString)).apply(fieldName)
+          result.errors mustEqual Seq(expectedError)
+      }
+    }
+
+  def stringFieldWithMinimumIntValue(form: Form[_], fieldName: String, min: Int, expectedError: FormError): Unit =
+    s"must not bind values < $min" in {
+      val testCase = min - 1
+      val result   = form.bind(Map(fieldName -> testCase.toString)).apply(fieldName)
+      result.errors mustEqual Seq(expectedError)
+    }
+
 }

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -85,6 +85,8 @@ trait Generators extends UserAnswersGenerator with ModelGenerators with ViewMode
       x => x > min && x < max
     )
 
+  def positiveIntsMinMax(min: Int, max: Int): Gen[Int] = Gen.choose(min, max)
+
   def positiveInts: Gen[Int] = Gen.choose(0, Int.MaxValue)
 
   def nonBooleans: Gen[String] =

--- a/test/views/incident/equipment/itemNumber/ItemNumberViewSpec.scala
+++ b/test/views/incident/equipment/itemNumber/ItemNumberViewSpec.scala
@@ -47,7 +47,7 @@ class ItemNumberViewSpec extends InputTextViewBehaviours[String] {
 
   behave like pageWithHeading()
 
-  behave like pageWithHint("This will be 4 characters long, for example 1234.")
+  behave like pageWithHint("This will be up to 4 characters long, for example 1999.")
 
   behave like pageWithInputText(Some(InputSize.Width20))
 

--- a/test/views/incident/equipment/itemNumber/ItemNumberViewSpec.scala
+++ b/test/views/incident/equipment/itemNumber/ItemNumberViewSpec.scala
@@ -47,7 +47,7 @@ class ItemNumberViewSpec extends InputTextViewBehaviours[String] {
 
   behave like pageWithHeading()
 
-  behave like pageWithHint("This will be up to 4 characters long, for example 1999.")
+  behave like pageWithHint("This can be up to 4 numbers long.")
 
   behave like pageWithInputText(Some(InputSize.Width20))
 


### PR DESCRIPTION
![Screenshot 2023-02-02 at 16 48 23](https://user-images.githubusercontent.com/40767309/217195874-0bb2a0e1-aed3-49c8-8eb8-e7bf65792c3f.png)

Screenshot shows a positive integer in the range 1-1999. 

The code has been updated accordingly. 

Also updated the content as per https://docs.google.com/document/d/1Gud5KL5bato1L9Rfa9vKkZ9O_zhzpj6x/edit